### PR TITLE
negative test failure

### DIFF
--- a/spec/rule_specs/negative_rule_spec.rb
+++ b/spec/rule_specs/negative_rule_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe "negative rule" do
+
+    before :each do
+      @engine = Wongi::Engine.create
+    end
+
+    def engine
+      @engine
+    end
+
+    context "with just one negative option" do
+
+      it "should not get a match" do
+
+        engine << rule('one-option') {
+          forall {
+            neg :Foo, :bar, :_
+          }
+          make {
+            action { |tokens|
+              raise "This should never get executed #{tokens}"
+            }
+          }
+        }
+
+      end
+
+    end
+
+end


### PR DESCRIPTION
Here is a test that fails.  I'm not sure what it means, really, but I bumped into it while fooling around.

It seems to me that this test should never be executed unless tokens[:Foo] is bound to SOMETHING (not nil).  

I could put a 
    diff :Foo, nil
and then I guess it'd pass, but that just doesn't seem right.
