### PR TITLE
Allow ncc to be searched for vars.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+*.swp

--- a/lib/wongi-engine/beta/ncc_node.rb
+++ b/lib/wongi-engine/beta/ncc_node.rb
@@ -13,6 +13,9 @@ module Wongi
         context
       end
 
+      def contains? var
+        children.any?{|child| child.contains? var}
+      end
     end
 
     class NccNode < BetaNode

--- a/spec/rule_specs/ncc_spec.rb
+++ b/spec/rule_specs/ncc_spec.rb
@@ -22,6 +22,19 @@ describe "NCC rule" do
     }
   end
 
+  def ncc_rule_post_has
+    rule('ncc post has') {
+      forall {
+        has "base", "is", :Base
+        none {
+          has :Base, 2, :X
+          has :X, 4, 5
+        }
+        has "base", "is", :Base2
+      }
+    }
+  end
+
   it 'should pass with a mismatching subchain' do
 
     engine << ncc_rule
@@ -45,6 +58,26 @@ describe "NCC rule" do
 
     engine << ncc_rule
     production = engine.productions['ncc']
+
+    engine << ["base", "is", 1]
+    engine << [1, 2, 3]
+    engine << [3, 4, 5]
+
+    production.should have(0).tokens
+
+    engine.retract [3, 4, 5]
+    production.should have(1).tokens
+
+    engine.retract ["base", "is", 1]
+    production.should have(0).tokens
+
+  end
+
+  it 'can handle an alpha node template introduced after the negative-conjunctive-condition' do
+
+    engine << ncc_rule_post_has
+
+    production = engine.productions['ncc post has']
 
     engine << ["base", "is", 1]
     engine << [1, 2, 3]


### PR DESCRIPTION
I was running into a problem where the NccSet came up in the compilation
of a new join node if you added a new alpha node via `has` after
declaring a NccSet in the rule DSL.

After reading the literature and code a bit, I experimented with having
the JoinNode check the children of the NccSet for the member. When that
started working, I added a `contains?` method to the NccSet.

I reasoned that it should be possible for me to add Alpha nodes at any
time in declaring the rule. It seems to me that Wongi is order-dependent
when binding variables, but the documentation and code doesn't seem to
require ordering of the different matchers so long as you introduce
variables in the order that you want to use them.

The literature was pretty difficult for me to comprehend and I don't
understnd it fully so I hope there are no edge cases introduced here
that change behavior of Alpha nodes and NCCs when adding Alpha nodes
after a NCC.

Well, the specs pass, so I hope this is acceptable. :)
