### PR TITLE
deprecate global dsl

### DIFF
--- a/spec/beta_node_spec.rb
+++ b/spec/beta_node_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe Wongi::Engine::BetaNode do
 
+  include Wongi::Engine::DSL
+
   let( :engine ) { Wongi::Engine.create }
 
   describe '#tokens' do

--- a/spec/high_level_spec.rb
+++ b/spec/high_level_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+include Wongi::Engine::DSL
+
 dsl {
 
   section :make


### PR DESCRIPTION
Rather than spamming the users with deprecation warnings for every rule, I decided to just do it once when we manually `include Wongi::Engine::DSL` into `Object`. That way it's also easy to remove when you elevate the deprecation to a public API change. I removed the inclusion and made sure the tests still passed with minimal changes.

Not sure if you wanted me to minor version bump or not. Figured I'd leave that to you. Happy to make any additional changes you'd like to see.