### PR TITLE
use StandardError instead of Exception

### DIFF
--- a/lib/wongi-engine/dsl/extension_clause.rb
+++ b/lib/wongi-engine/dsl/extension_clause.rb
@@ -18,8 +18,8 @@ module Wongi::Engine
         a.rete = rete if a.respond_to? :rete=
         a
       end
-    rescue Exception => e
-      e1 = Exception.new "error defining clause #{name} handled by #{action}: #{e}"
+    rescue StandardError => e
+      e1 = StandardError.new "error defining clause #{name} handled by #{action}: #{e}"
       e1.set_backtrace e.backtrace
       raise e1
     end

--- a/lib/wongi-engine/error.rb
+++ b/lib/wongi-engine/error.rb
@@ -1,6 +1,6 @@
 module Wongi::Engine
 
-  class Error < ::Exception
+  class Error < StandardError
 
   end
 

--- a/lib/wongi-engine/ruleset.rb
+++ b/lib/wongi-engine/ruleset.rb
@@ -36,8 +36,8 @@ module Wongi
       def install rete
         # puts "Installing ruleset #{name}"
         @rules.each { |rule| rete << rule }
-      rescue Exception => e
-        e1 = Exception.new "error installing ruleset '#{name||'<unnamed>'}': #{e}"
+      rescue StandardError => e
+        e1 = StandardError.new "error installing ruleset '#{name||'<unnamed>'}': #{e}"
         e1.set_backtrace e.backtrace
         raise e1
       end


### PR DESCRIPTION
I remember reading this a while back: https://robots.thoughtbot.com/rescue-standarderror-not-exception

tldr; should probably use `StandardError` instead of `Exception` since ruby uses `Exception` internally to catch interrupt flavored events. Figured I'd nip it while it was on my mind.