### PR TITLE
Fix Error Collector

### DIFF
--- a/lib/wongi-engine/dsl/action/error_generator.rb
+++ b/lib/wongi-engine/dsl/action/error_generator.rb
@@ -6,9 +6,9 @@ module Wongi::Engine
         @message, @messenger = message, messenger
       end
 
-      def rete=
+      def rete=(*)
         super
-        rete.add_collector :error, self
+        rete.add_collector self, :error
       end
 
       def errors

--- a/spec/high_level_spec.rb
+++ b/spec/high_level_spec.rb
@@ -160,6 +160,23 @@ describe 'the engine' do
 
   end
 
+  it "should properly show error messages" do
+    rete << rule("Error rule") {
+      forall {
+        has :_, :_, :TestNumber
+        greater :TestNumber, 0
+      }
+      make {
+        error "An error has occurred"
+      }
+    }
+
+    rete << [ "A", "B", 1 ]
+
+    error_messages = rete.errors.map(&:message)
+    expect(error_messages).to eq(["An error has occurred"])
+  end
+
   it 'should use generic collectors' do
 
     rete << rule('generic-collector') {


### PR DESCRIPTION
We fix the method signature of ErrorCollector#rete= and ensure that this
method properly sets the error collector on the rete.