### PR TITLE
Fix issue using statement generator with overlays

### DIFF
--- a/lib/wongi-engine/beta/beta_memory.rb
+++ b/lib/wongi-engine/beta/beta_memory.rb
@@ -19,6 +19,7 @@ module Wongi::Engine
     def beta_activate token
       existing = tokens.find { |et| et.duplicate? token }
       return if existing # TODO really?
+      return unless token.overlay
       token.overlay.add_token(token, self)
       children.each do |child|
         child.beta_activate token

--- a/lib/wongi-engine/beta/ncc_node.rb
+++ b/lib/wongi-engine/beta/ncc_node.rb
@@ -12,7 +12,8 @@ module Wongi
       def beta_activate token
         return if tokens.find { |t| t.parent == token }
         t = Token.new self, token, nil, {}
-        t.overlay.add_token(t, self)
+        return unless t.overlay        
+        t.overlay.add_token(t, self)                
         partner.tokens.each do |ncc_token|
           next unless ncc_token.ancestors.find { |a| a.equal? token }
           t.ncc_results << ncc_token

--- a/lib/wongi-engine/beta/ncc_partner.rb
+++ b/lib/wongi-engine/beta/ncc_partner.rb
@@ -9,6 +9,7 @@ module Wongi
       def beta_activate token
         t = Token.new self, token, nil, {}
         owner = owner_for( t )
+        return unless t.overlay
         t.overlay.add_token(t, self)
         if owner
           owner.ncc_results << t

--- a/lib/wongi-engine/beta/neg_node.rb
+++ b/lib/wongi-engine/beta/neg_node.rb
@@ -52,6 +52,7 @@ module Wongi
 
       def beta_activate token
         return if tokens.find { |et| et.duplicate? token }
+        return unless token.overlay
         token.overlay.add_token(token, self)
         alpha.wmes.each do |wme|
           if matches?( token, wme )

--- a/lib/wongi-engine/beta/optional_node.rb
+++ b/lib/wongi-engine/beta/optional_node.rb
@@ -65,6 +65,7 @@ module Wongi
       def beta_activate t
         return if tokens.find { |token| token.parent == t }
         token = Token.new( self, t, nil, { } )
+        return unless token.overlay
         token.overlay.add_token(token, self)
         match = false
         alpha.wmes.each do |wme|


### PR DESCRIPTION
No idea why, but when we use overlays with a statement generator we are finding that the token doesn't include an overlay.

This fix resolves the problem, but I imagine it'll have some terrible consequence in the future that we haven't noticed yet...

We are invoking the statement generator from within an action like this:

```
      fact = Wongi::Engine::Template.new(membership, key, value)

      generator = Wongi::Engine::DSL::Action::StatementGenerator.new fact
      generator.rete = rete
      generator.production = production
      generator.execute token
```